### PR TITLE
fix: add translation for shipping sku

### DIFF
--- a/inc/Service/Lineitem.php
+++ b/inc/Service/Lineitem.php
@@ -104,7 +104,7 @@ class WalleeServiceLineitem extends WalleeServiceAbstract
             $item->setAmountIncludingTax($this->roundAmount($shippingCosts, $currencyCode));
             $item->setQuantity(1);
             $item->setShippingRequired(false);
-            $item->setSku('shipping');
+            $item->setSku(WalleeHelper::getModuleInstance()->l('Shipping', 'lineitem'));
             $name = "";
             $taxCalculatorFound = false;
             if (isset($summary['carrier']) && $summary['carrier'] instanceof Carrier) {
@@ -384,7 +384,7 @@ class WalleeServiceLineitem extends WalleeServiceAbstract
                 $name = '';
                 $item->setQuantity(1);
                 $item->setShippingRequired(false);
-                $item->setSku('shipping');
+                $item->setSku(WalleeHelper::getModuleInstance()->l('Shipping', 'lineitem'));
                 $item->setAmountIncludingTax($this->roundAmount($shippingCosts, $currencyCode));
 
                 $carrier = new Carrier($order->id_carrier);


### PR DESCRIPTION
On LineItem 'Shipping' the SKU is now translatable in prestashop.